### PR TITLE
Fix logo rendering on Chrome

### DIFF
--- a/components/event-cover/style.css
+++ b/components/event-cover/style.css
@@ -17,11 +17,6 @@
   padding: 3em;
 }
 
-.event-cover > .brand > svg {
-  height: 10em;
-  width: 10em;
-}
-
 .event-cover > .info {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
         <div class="brand">
           <svg
             viewBox="0 0 400 400"
+            width="160"
+            height="160"
             version="1.1"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
Quick workaround to fix the rendering issue of the svg logo in html2canvas. Fixes half of #4 

[Seems to be reported in their repo](https://github.com/niklasvh/html2canvas/issues/1011) that when working with some css styles applied to svg elements this may happen. I just moved the `width` and `height` attributes from the stylesheet into the svg markup as native inline svg attributes.

Btw, the rendering issue was not originally present in Firefox or Safari. Could have downloaded the past Facebook event images from those browsers lol 🤷‍♀️  